### PR TITLE
add time_based_data_adjustment to industrial dataset

### DIFF
--- a/project/project.json5
+++ b/project/project.json5
@@ -56,6 +56,12 @@
     {
       dataset_id: 'decarb_2023_industry',
       wrap_time_allowed: true,
+      time_based_data_adjustment: {
+        daylight_saving_adjustment: {
+          spring_forward_hour: drop,
+	  fall_back_hour: duplicate,
+	},
+      },
       dataset_type: 'modeled',
       version: '1.0.0',
       required_dimensions: {


### PR DESCRIPTION
Currently dsgrid's index time config assumes the same behavior for `time_based_data_adjustment = None` as
```
time_based_data_adjustment = TimeBasedDataAdjustmentModel(
        daylight_saving_adjustment={
            "spring_forward_hour": "drop",
            "fall_back_hour": "duplicate",
        }
    ) 
```

We need to separate out these two behaviors to allow index time to handle local/unaligned time without time_based_data_adjustment.