### PR TITLE
Industrial time to use interpolation

### DIFF
--- a/project/project.json5
+++ b/project/project.json5
@@ -59,7 +59,7 @@
       time_based_data_adjustment: {
         daylight_saving_adjustment: {
           spring_forward_hour: drop,
-	  fall_back_hour: duplicate,
+	  fall_back_hour: interpolate,
 	},
       },
       dataset_type: 'modeled',


### PR DESCRIPTION
For after DuckdB PR merge in dsgrid.
Allow industrial time to use data interpolation for the fallback hour